### PR TITLE
Added activePage prop and fix bug where 0 appears when last page is max pages - 1

### DIFF
--- a/src/PaginationComponent.js
+++ b/src/PaginationComponent.js
@@ -6,7 +6,7 @@ class PaginationComponent extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            activePage: 1,
+            activePage: this.props.activePage,
             firstPaginationNumber: 1
         }
         this.pages = this.getNumberOfPages(this.props);
@@ -135,11 +135,13 @@ PaginationComponent.propTypes = {
     totalItems: PropTypes.number.isRequired,
     pageSize: PropTypes.number.isRequired,
     onSelect: PropTypes.func.isRequired,
-    maxPaginationNumbers: PropTypes.number
+    maxPaginationNumbers: PropTypes.number,
+    activePage: PropTypes.number
 }
 
 PaginationComponent.defaultProps = {
-    maxPaginationNumbers: 5
+    maxPaginationNumbers: 5,
+    activePage: 1
 }
 
 export default PaginationComponent;

--- a/src/PaginationComponent.js
+++ b/src/PaginationComponent.js
@@ -105,7 +105,7 @@ class PaginationComponent extends Component {
         const distance = Math.floor(this.props.maxPaginationNumbers / 2);
         const newFPNumber = activePage - distance;
         const newLPNumber = activePage + distance;
-        if (newFPNumber <= 1) {
+        if (newFPNumber <= distance) {
             if (this.state.firstPaginationNumber !== 1) {
                 this.setState({
                     firstPaginationNumber: 1


### PR DESCRIPTION
Added an activePage prop that allows you to pass in the start page. 
Useful if you want to handle page numbers in path for example news?page=2

Found a bug in handlePaginationNumber's calculation of firstPaginationNumber where 0 would appear as the first page if the total number of pages = max page -1 and you click onto the last page. 

For Example if total items = 12, items per page = 3,and max page = 5, then the last page is 4
If you click onto 4 the first page changes to 0