### PR TITLE
State activePage should change on props change

### DIFF
--- a/src/PaginationComponent.js
+++ b/src/PaginationComponent.js
@@ -14,6 +14,9 @@ class PaginationComponent extends Component {
 
     componentWillReceiveProps(props) {
         this.pages = this.getNumberOfPages(props);
+        this.setState({
+           activePage:props.activePage
+        });
         this.forceUpdate();
     }
 


### PR DESCRIPTION
If we have search functionality, in that case, total items count will get change so we should update activePage as well.